### PR TITLE
Update href used by clarity to cache assets

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Clarify",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Fixes resource loading issues with Microsoft Clarity.",
     "author": "Murtaza Latif <taaz.murr@gmail.com>",
     "icons": {

--- a/observer.js
+++ b/observer.js
@@ -15,7 +15,7 @@ const initializeObserver = () => {
   const clarityObserver = new MutationObserver((mutationsList) => {
     const iframe = document.querySelector("iframe");
     let resources = iframe.contentDocument.querySelectorAll(
-      'link[href*="https://clarity.microsoft.com/external/v2/resources"]'
+      'link[href*="https://tm-cachedresources.trafficmanager.net/cached-resources/api/resources/"]'
     );
     console.log({ iframe, cd: iframe.contentDocument, resources });
     for (let resource of resources) {


### PR DESCRIPTION
Somewhere along the way since this extension was created, the base URL that the extension looks for to perform the substitution was changed by Clarity. This change updates it to what's being used now.